### PR TITLE
Implement Cloudinary Video Player

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -12,3 +12,6 @@ application.register("place", PlaceController)
 
 import RecordVideoController from "./record_video_controller"
 application.register("record-video", RecordVideoController)
+
+import VideoController from "./video_controller"
+application.register("video", VideoController)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -12,6 +12,3 @@ application.register("place", PlaceController)
 
 import RecordVideoController from "./record_video_controller"
 application.register("record-video", RecordVideoController)
-
-import VideoController from "./video_controller"
-application.register("video", VideoController)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,8 +13,8 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
 
-    <%= stylesheet_link_tag 'https://unpkg.com/cloudinary-video-player@1.9.9/dist/cld-video-player.min.css' %>
-    <%= javascript_include_tag 'https://unpkg.com/cloudinary-video-player@1.9.9/dist/cld-video-player.min.js' %>
+    <%= stylesheet_link_tag "https://unpkg.com/cloudinary-video-player@1.9.9/dist/cld-video-player.light.min.css" %>
+    <%= javascript_include_tag "https://unpkg.com/cloudinary-video-player@1.9.9/dist/cld-video-player.light.min.js" %>
   </head>
 
   <body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,15 +3,18 @@
   <head>
     <%= stylesheet_link_tag 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css' %>
     <%= stylesheet_link_tag 'favourites', media: 'all' %>
-    
+
     <title>ReelReviews</title>
-    
+
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+
+    <%= stylesheet_link_tag 'https://unpkg.com/cloudinary-video-player@1.9.9/dist/cld-video-player.min.css' %>
+    <%= javascript_include_tag 'https://unpkg.com/cloudinary-video-player@1.9.9/dist/cld-video-player.min.js' %>
   </head>
 
   <body>

--- a/app/views/places/_post.html.erb
+++ b/app/views/places/_post.html.erb
@@ -1,9 +1,20 @@
-<%= cl_video_tag(
-  post.video_url,
-  class: "video",
-  autoplay: true,
-  muted: true,
-  loop: true,
-  controls: true,
-  fallback_content: "Your browser does not support HTML5 video tags."
-) %>
+<video id ="post_<%= post.id %>_video" class="video cld-video-player"></video>
+
+
+<script>
+  var cloudinary_video_player = cloudinary.videoPlayer("post_<%= post.id %>_video",{
+    cloud_name: 'dwang9o22',
+    fluid: true,
+    controls: true,
+    muted: true,
+    controlBar: {
+      volumePanel: false,
+      fullscreenToggle: false
+    },
+    hideContextMenu: true,
+    autoplay: true,
+    loop: true
+  });
+
+  cloudinary_video_player.source("<%= post.video_public_id %>");
+</script>

--- a/app/views/places/_post.html.erb
+++ b/app/views/places/_post.html.erb
@@ -5,16 +5,26 @@
   var cloudinary_video_player = cloudinary.videoPlayer("post_<%= post.id %>_video",{
     cloud_name: 'dwang9o22',
     fluid: true,
-    controls: true,
     muted: true,
+    showLogo: false,
+    controls: true,
     controlBar: {
-      volumePanel: false,
-      fullscreenToggle: false
+      playToggle: false,
+      volumeMenuButton: false,
+      fullscreenToggle: false,
+      currentTimeDisplay: false,
+      timeDivider: false,
+      durationDisplay: false,
+      remainingTimeDisplay: false,
+      progressControl: true
     },
     hideContextMenu: true,
     autoplayMode: 'on-scroll',
     autoplay: true,
-    loop: true
+    loop: true,
+
+    // To prevent fullscreen on iOS
+    playsinline: true
   });
 
   cloudinary_video_player.source("<%= post.video_public_id %>");

--- a/app/views/places/_post.html.erb
+++ b/app/views/places/_post.html.erb
@@ -12,6 +12,7 @@
       fullscreenToggle: false
     },
     hideContextMenu: true,
+    autoplayMode: 'on-scroll',
     autoplay: true,
     loop: true
   });


### PR DESCRIPTION
This pull request updates the `app/views/layouts/application.html.erb` and `app/views/places/_post.html.erb` files to implement changes related to the Cloudinary video player.

For `app/views/layouts/application.html.erb`, a stylesheet and a javascript file for the Cloudinary video player have been added to the header.

For `app/views/places/_post.html.erb`, the previous HTML5 video player is replaced with the Cloudinary video player to leverage its advanced functionalities.

Added autoplay on scroll.

Fullscreen mode on iOS is disabled to maintain consistency across devices.

Still need to style it to only show the progress bar as controls. We don't want the colour background.