### PR TITLE
Opening hours text formatting + removed duplicate location text

### DIFF
--- a/app/assets/stylesheets/pages/places_show.css
+++ b/app/assets/stylesheets/pages/places_show.css
@@ -34,6 +34,7 @@
 .location p {
   font-size: 16px;
   margin-bottom: 5px;
+  line-height: 1.4;
 }
 
 #map-container {

--- a/app/views/places/show.html.erb
+++ b/app/views/places/show.html.erb
@@ -10,17 +10,15 @@
     </div>
     <div class="opening-times">
       <h2>Opening times</h2>
-      <p>Opening Times: <%= @place.opening_hours %></p>
+      <p><%= simple_format(@place.opening_hours) %></p>
     </div>
     <div class="location">
       <h2>Location</h2>
       <p>Location: <%= @place.address %></p>
     </div>
   </div>
-  
-  <div 
+
+  <div
   data-map-markers-value="<%= @markers.to_json %>"
   id="map-container" data-controller="map" data-map-api-key-value="<%= ENV['MAPBOX_API_KEY'] %>"></div>
 </div>
-
-


### PR DESCRIPTION
This pull request updates the CSS and HTML in the places' show page.

- The 'simple_format' method is used to handle newlines in the 'opening_hours' field.
- In the CSS file, a line-height is added to improve readability of the opening hours.
- In the HTML file, redundant "Opening Times" and "Location" text is removed for brevity and clarity.