### PR TITLE
Reverted addition of element that covered part of navbar line, to work with immediate video display

### DIFF
--- a/app/assets/stylesheets/components/new_video.css
+++ b/app/assets/stylesheets/components/new_video.css
@@ -8,18 +8,6 @@
   z-index: 2;
 }
 
-#invisible-block {
-  width: 7rem;
-  background-color: #0D003F;
-  height: 2rem;
-  z-index: 5;
-  position: fixed;
-  left: 0.3rem;
-  right: 0;
-  margin: 0 auto;
-  bottom: 2rem;
-}
-
 #record-video-buttons {
   text-align: center;
   position: fixed;

--- a/app/views/posts/_new_video.html.erb
+++ b/app/views/posts/_new_video.html.erb
@@ -1,8 +1,5 @@
 <video id="videoElement" class="flipped" data-record-video-target="videoElement" autoplay muted playsinline></video>
 
-<%# Invisible block to give hide parts of the navbar line for better visual integration with the record button %>
-<div id="invisible-block"></div>
-
 <div id="record-video-buttons">
   <button id="record-button" data-action="click->record-video#toggleRecording" data-target="record-video.recordButton">
   </button>


### PR DESCRIPTION
Removed element that covered part of navbar line since it doesn't work now video is (nice!) immediately displayed.